### PR TITLE
Initialize Telegram webhook bot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.env
+.env.*
+venv/

--- a/main.py
+++ b/main.py
@@ -1,0 +1,41 @@
+import logging
+import os
+
+from telegram import Update
+from telegram.ext import (
+    ApplicationBuilder,
+    ContextTypes,
+    CommandHandler,
+)
+
+logging.basicConfig(level=logging.INFO)
+
+TOKEN = os.environ.get("TELEGRAM_BOT_TOKEN")
+WEBHOOK_URL = os.environ.get("WEBHOOK_URL")
+PORT = int(os.environ.get("PORT", 8443))
+
+if not TOKEN:
+    raise RuntimeError("TELEGRAM_BOT_TOKEN environment variable not set")
+if not WEBHOOK_URL:
+    raise RuntimeError("WEBHOOK_URL environment variable not set")
+
+async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await update.message.reply_text("Hello! I'm alive.")
+
+
+def main() -> None:
+    application = ApplicationBuilder().token(TOKEN).build()
+
+    application.add_handler(CommandHandler("start", start))
+
+    # Set up the webhook and run the web server
+    application.run_webhook(
+        listen="0.0.0.0",
+        port=PORT,
+        url_path=TOKEN,
+        webhook_url=f"{WEBHOOK_URL}/{TOKEN}",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,24 @@
-readme
+# Telegram Webhook Bot
+
+This project contains a minimal Telegram bot using the `python-telegram-bot` library.
+The bot runs using a webhook so it can receive updates from Telegram via an HTTP
+endpoint.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Set the following environment variables:
+   - `TELEGRAM_BOT_TOKEN` – your bot token from BotFather.
+   - `WEBHOOK_URL` – the public URL where Telegram can reach your bot
+     (for example, `https://example.com/webhook`).
+   - `PORT` *(optional)* – port for the local web server (defaults to `8443`).
+3. Run the bot:
+   ```bash
+   python main.py
+   ```
+
+The bot registers the webhook automatically and starts an HTTP server to
+receive updates.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+python-telegram-bot[webhooks]==20.6


### PR DESCRIPTION
## Summary
- add minimal Telegram webhook bot using python-telegram-bot library
- describe setup in README
- add requirements and `.gitignore`

## Testing
- `python -m py_compile main.py`
- `python main.py --help` *(fails: ModuleNotFoundError: No module named 'telegram')*

------
https://chatgpt.com/codex/tasks/task_e_68651c95fcec83338ee9e8ff18b944cb