### PR TITLE
Add README instructions for local webhook testing

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,3 +22,22 @@ endpoint.
 
 The bot registers the webhook automatically and starts an HTTP server to
 receive updates.
+
+## Local testing with webhooks
+
+If you want to run the bot locally before deploying it, you need a public
+URL that Telegram can reach. The easiest approach is to use a tunneling
+service like **ngrok**.
+
+1. [Download and install ngrok](https://ngrok.com/).
+2. Start a tunnel to the port your bot listens on (by default `8443`):
+
+   ```bash
+   ngrok http 8443
+   ```
+
+   Copy the HTTPS URL shown in the ngrok output (for example
+   `https://abc123.ngrok.io`).
+3. Set `WEBHOOK_URL` to the HTTPS address from step 2.
+4. Run the bot as described above. Telegram will deliver updates to your
+   local instance through the tunnel.


### PR DESCRIPTION
## Summary
- document how to expose a local webhook using ngrok

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68651eb844a883338e3d3edc6f09edf2