### PR TITLE
Add Yandex Cloud Functions support

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import json
 
 from telegram import Update
 from telegram.ext import (
@@ -14,30 +15,49 @@ TOKEN = os.environ.get("TELEGRAM_BOT_TOKEN")
 WEBHOOK_URL = os.environ.get("WEBHOOK_URL")
 PORT = int(os.environ.get("PORT", 8443))
 
+
 if not TOKEN:
     raise RuntimeError("TELEGRAM_BOT_TOKEN environment variable not set")
-if not WEBHOOK_URL:
-    raise RuntimeError("WEBHOOK_URL environment variable not set")
 
 async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if update.message:
         await update.message.reply_text("Hello! I'm alive.")
 
 
+application = ApplicationBuilder().token(TOKEN).build()
+application.add_handler(CommandHandler("start", start))
+
+_initialized = False
+
+
 def main() -> None:
-    if (not TOKEN):    
-        raise Exception("NO TOKEN PROVIDED")
-    application = ApplicationBuilder().token(TOKEN).build()
-
-    application.add_handler(CommandHandler("start", start))
-
-    # Set up the webhook and run the web server
+    if not WEBHOOK_URL:
+        raise RuntimeError("WEBHOOK_URL environment variable not set")
+    # Set up the webhook and run the web server for local development
     application.run_webhook(
         listen="0.0.0.0",
         port=PORT,
         url_path=TOKEN,
         webhook_url=f"{WEBHOOK_URL}/{TOKEN}",
     )
+
+
+async def handler(event, context):
+    """Yandex Cloud Functions entry point."""
+    global _initialized
+    if not _initialized:
+        await application.initialize()
+        _initialized = True
+
+    if event.get("httpMethod") == "POST" and event.get("body"):
+        if event.get("path", "/").lstrip("/") != TOKEN:
+            return {"statusCode": 403, "body": "forbidden"}
+        update = Update.de_json(json.loads(event["body"]), application.bot)
+        await application.process_update(update)
+    return {
+        "statusCode": 200,
+        "body": "ok",
+    }
 
 
 if __name__ == "__main__":

--- a/readme.md
+++ b/readme.md
@@ -41,3 +41,15 @@ service like **ngrok**.
 3. Set `WEBHOOK_URL` to the HTTPS address from step 2.
 4. Run the bot as described above. Telegram will deliver updates to your
    local instance through the tunnel.
+
+## Deploying to Yandex Cloud Functions
+
+To run the bot as a serverless function:
+
+1. Create a Python runtime function in the Yandex Cloud console.
+2. Upload the code along with `requirements.txt`.
+3. Set the handler to `main.handler`.
+4. Set the environment variable `TELEGRAM_BOT_TOKEN` with your bot token.
+5. Configure an API gateway or trigger so Telegram sends updates to
+   `https://<gateway-address>/<TELEGRAM_BOT_TOKEN>`.
+6. Telegram will POST updates to the function and the bot will respond.


### PR DESCRIPTION
## Summary
- add a serverless handler in `main.py` for running in Yandex Cloud Functions
- document how to deploy to Yandex Cloud

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6865235edd60833393b2bd19124d004b